### PR TITLE
Add Parenting Long Reads Part 2

### DIFF
--- a/src/content/blog/why-preschoolers-seem-so-clever-and-so-irrational.md
+++ b/src/content/blog/why-preschoolers-seem-so-clever-and-so-irrational.md
@@ -1,0 +1,424 @@
+---
+title: "Why Preschoolers Seem So Clever and So Irrational"
+description: "A practical long read on why three-year-olds can sound grown up one minute and fall apart the next."
+pubDate: 2026-07-01T08:00:00Z
+draft: false
+seriesSlug: parenting-long-reads
+seriesTitle: Parenting Long Reads
+seriesPart: 2
+seriesDisclaimer: true
+---
+
+A three-year-old can be astonishingly articulate.
+
+They can remember something you promised two days ago. They can correct you when you get a story wrong. They can make a surprisingly persuasive case for why they should have one more biscuit. They can use phrases that sound almost adult.
+
+And then, five minutes later, they can completely fall apart because the banana broke, the wrong parent opened the car door, or the bath water is not the exact kind of warm they had in mind.
+
+This is one of the strange things about parenting a preschooler: they often sound more grown up than they are.
+
+That gap is the topic of today’s long read.
+
+Why can a young child seem so clever, funny, and verbally capable, but still struggle so much with tiny frustrations?
+
+The short answer is this:
+
+**Their language and imagination are developing faster than their emotional control.**
+
+That does not mean they are badly behaved. It does not mean they are manipulating you. It does not mean boundaries do not matter.
+
+It means their brain is still under construction.
+
+## The uneven child
+
+Adults tend to expect development to move in a neat line.
+
+Once a child can explain something, we assume they can handle it.
+
+Once they know the rule, we assume they can follow it.
+
+Once they can say sorry, we assume they understand what sorry means.
+
+Once they can tell us what they want, we assume they should be able to cope when they do not get it.
+
+But young children do not develop evenly.
+
+A preschooler may have enough language to describe a problem, but not enough self-control to manage the feeling that comes with it.
+
+They may know that hitting is wrong, but still hit when flooded by frustration.
+
+They may understand that a toy belongs to someone else, but still grab it when desire takes over.
+
+They may be able to say, “I’ll wait my turn,” and then find waiting almost physically unbearable.
+
+The CDC’s developmental milestones for three-year-olds include things like having conversations with at least two back-and-forth exchanges, asking who, what, where, or why questions, calming down within about ten minutes after being left at childcare, and playing with other children. That is a lot of growth. But these are still milestones for a very young child, not signs that the child now has adult-like emotional control.
+
+So the first useful idea is this:
+
+**Capability is patchy.**
+
+Your preschooler may be advanced in one moment and completely overwhelmed in the next.
+
+That is normal.
+
+## The brain is not finished in the order parents would choose
+
+If parents could choose the order of child development, emotional regulation would probably arrive very early.
+
+Imagine it: a toddler who can say, “I am disappointed, but I accept your boundary.”
+
+Sadly, this is not the usual sequence.
+
+Language, movement, memory, and imagination all grow quickly in the early years. The systems involved in planning, impulse control, flexible thinking, and managing strong feelings take much longer.
+
+These skills are often grouped under the term **executive function**. Harvard’s Center on the Developing Child describes executive function and self-regulation as the mental processes that help us focus attention, remember instructions, plan, and handle multiple demands. These skills begin developing early, but they are built gradually through childhood, adolescence, and even into adulthood.
+
+That matters because many everyday parenting flashpoints are really executive-function problems wearing tiny shoes.
+
+Getting dressed is not just getting dressed. It involves stopping play, remembering the next step, tolerating scratchy clothes, choosing between options, and coping with the fact that someone else is in charge of the schedule.
+
+Leaving the park is not just leaving the park. It involves shifting attention, handling disappointment, understanding time, and accepting that future-you can come back another day even though present-you wants the slide now.
+
+Sharing is not just being nice. It involves impulse control, perspective-taking, patience, social rules, and trust that you will get another turn.
+
+Seen that way, a lot of preschool behaviour becomes less mysterious.
+
+It is not that the request is always too hard.
+
+It is that the request often asks a young child to use several immature skills at once.
+
+## Why small things become huge
+
+To adults, a broken banana is not a crisis.
+
+To a young child, it might be.
+
+That sounds ridiculous until you remember that children live very close to the surface of experience. They do not have much perspective yet. They cannot reliably zoom out and think, “This is annoying, but in the scheme of my day it is minor.”
+
+They feel the immediate thing strongly.
+
+Also, preschoolers are beginning to care about control.
+
+They want to choose. They want to do things themselves. They want the ritual to happen in the right order. They want to be treated as capable, but they still need a lot of help.
+
+This creates a daily tension:
+
+> “I am big. I am small. Let me do it. Help me. Not like that.”
+
+That tension shows up everywhere.
+
+They want to pour the cereal, but spill it.
+
+They want to choose their clothes, but cannot choose quickly.
+
+They want to climb into the car seat themselves, but only when you are already late.
+
+They want independence, but not separation.
+
+They want control, but not responsibility.
+
+This is not hypocrisy. It is development.
+
+A preschooler is practising being a person.
+
+Practising is messy.
+
+## The problem with asking “why?”
+
+When children do something baffling, adults often ask:
+
+> “Why did you do that?”
+
+Sometimes this is useful. Often it is not.
+
+A three-year-old may not know why they pushed their sibling, screamed at the stairs, or threw the shoe. Or they may give an answer that is true but incomplete: “Because I wanted to.”
+
+That is not evasive. It may be the best explanation available to them.
+
+A lot of behaviour at this age happens before the child has much conscious access to the reason.
+
+The feeling comes first.
+
+The action comes next.
+
+The explanation comes later, if at all.
+
+So instead of starting with “why?”, it is often more useful to start with what you can see:
+
+> “You were angry because he took the car.”
+
+> “You wanted to do it yourself.”
+
+> “You didn’t want bath time to start.”
+
+> “You were having fun and it was hard to stop.”
+
+This gives the child a possible map of their own behaviour.
+
+Over time, that map becomes part of how they understand themselves.
+
+But in the moment, the aim is not to extract a courtroom confession.
+
+The aim is to help the child connect feeling, action, and boundary.
+
+## Boundaries still matter
+
+There is a risk with child development language: it can sound like everything should be understood and nothing should be stopped.
+
+That is not right.
+
+Understanding why a behaviour happens does not mean allowing it.
+
+A useful formula is:
+
+**Name the feeling. Hold the boundary. Offer the next step.**
+
+For example:
+
+> “You’re angry that he has the toy. I won’t let you hit. You can say, ‘my turn next,’ or we can find another car.”
+
+Or:
+
+> “You don’t want to leave. The park is finished for today. You can walk to the gate or I can carry you.”
+
+Or:
+
+> “You wanted the banana whole. It broke. I can’t fix that. You can eat this one or leave it.”
+
+This is not soft parenting.
+
+It is clear parenting.
+
+The feeling is allowed.
+
+The unsafe or impossible behaviour is not.
+
+That distinction matters.
+
+A child who hears “don’t be silly” or “stop crying” may learn that the feeling itself is the problem.
+
+A child who hears “you’re disappointed, and the answer is still no” gets a more useful lesson.
+
+They learn that feelings can be big without becoming the boss.
+
+## What about tantrums?
+
+Tantrums are one of the clearest examples of the gap between ability and regulation.
+
+The American Academy of Pediatrics explains tantrums as common in young children, often linked to frustration, hunger, tiredness, overstimulation, or wanting more independence than they can yet manage. That fits the daily reality of preschool life very well.
+
+A tantrum is not always a deliberate strategy.
+
+Sometimes it is a child’s nervous system doing the only thing it can do when overloaded.
+
+That does not mean tantrums should get children everything they want.
+
+If a child learns that screaming always produces the biscuit, then yes, screaming becomes a strategy.
+
+But the answer is not to treat every tantrum as manipulation.
+
+The answer is to keep the boundary while helping the child through the storm.
+
+A simple approach:
+
+1. Make sure everyone is safe.
+2. Say very little.
+3. Stay nearby if they want you nearby.
+4. Do not negotiate mid-tantrum.
+5. Reconnect afterwards.
+
+During the storm, language often does not land. Too many words can make things worse.
+
+Afterwards, when the child is calm, you can briefly name what happened:
+
+> “You were very upset because I said no to another episode. You screamed and threw the cushion. Next time you can say, ‘I’m cross.’ I won’t let you throw things at people.”
+
+Short. Calm. Done.
+
+The lesson after the storm matters more than the lecture during it.
+
+## Why tiredness changes everything
+
+One reason preschool behaviour can feel so unpredictable is that the same child is not really the same child at every point of the day.
+
+A well-fed, rested three-year-old on a quiet morning may be funny, flexible, and helpful.
+
+The same child at 5:20pm after nursery, hunger, noise, and a missed nap may become a tiny chaos engine.
+
+This is not because their values changed.
+
+It is because regulation is state-dependent.
+
+Tired children have less capacity. Hungry children have less capacity. Overstimulated children have less capacity. Children in transition have less capacity.
+
+Adults are the same, frankly. We just hide it better.
+
+This is worth remembering because it changes the question.
+
+Instead of asking, “Why are they being so difficult?”, you can ask:
+
+> “What demand is too high for the capacity they have right now?”
+
+That does not solve everything, but it often points to a better response.
+
+At 8am, a choice between three outfits may be fine.
+
+At 6pm, it may be too much.
+
+At the weekend, leaving the house through a playful race may work.
+
+On a rushed nursery morning, the same game may become a battle.
+
+The skill is not finding one perfect parenting technique.
+
+The skill is reading the room.
+
+## Practical things to try this week
+
+Here are a few simple experiments.
+
+### 1. Use fewer words during the hard bit
+
+When your child is escalating, try cutting your language in half.
+
+Instead of:
+
+> “I’ve told you already that we can’t do that because we’re going to be late and you need to listen when I ask you to get your shoes on.”
+
+Try:
+
+> “Shoes now. Then car.”
+
+Or:
+
+> “You’re cross. I’m here. Shoes now.”
+
+Explanations are useful when the child is calm. During escalation, they often add load.
+
+### 2. Name the hidden skill
+
+When something goes wrong, ask yourself: what skill is this actually asking for?
+
+Waiting?
+
+Switching tasks?
+
+Handling disappointment?
+
+Stopping an impulse?
+
+Sharing attention?
+
+Choosing between options?
+
+This helps you see the behaviour differently.
+
+Instead of “they are being awkward”, you might see “they are struggling to transition”.
+
+That often leads to a better intervention.
+
+### 3. Give controlled choices
+
+Preschoolers often need some control, but too much choice can overwhelm them.
+
+So use small choices inside firm boundaries:
+
+> “Red cup or green cup?”
+
+> “Walk upstairs or be carried?”
+
+> “Pyjamas first or teeth first?”
+
+The adult owns the frame. The child gets some agency inside it.
+
+### 4. Preview transitions
+
+Many young children struggle when one activity suddenly ends.
+
+Try:
+
+> “Two more goes, then we leave.”
+
+> “After this book, lights out.”
+
+> “When the timer beeps, bath is finished.”
+
+This will not magically prevent all protests. But it gives the child a bridge between now and next.
+
+### 5. Repair without drama
+
+If you lose your temper, repair it simply.
+
+> “I shouted. Sorry. I was frustrated, but I should not have shouted.”
+
+You do not need to over-explain.
+
+Repair teaches emotional responsibility better than pretending adults are always calm.
+
+## What this means for younger siblings
+
+If there is also a one-year-old in the house, the contrast can be useful.
+
+With a one-year-old, you naturally expect limited regulation. You expect grabbing, crying, pointing, dropping, crawling away, and wanting things immediately.
+
+With a three-year-old, it is easier to forget they are still little.
+
+But the older child is still much closer to the baby than to the adult.
+
+They have more language, more memory, and more social awareness, but they are still early in learning how to manage themselves.
+
+This matters for sibling conflict.
+
+The older child may genuinely love the younger one and still be furious when toys are grabbed, attention is shared, or carefully built games are interrupted.
+
+A useful phrase is:
+
+> “You can be angry. You can’t hurt him.”
+
+That sentence does a lot.
+
+It validates the feeling, holds the boundary, and avoids shaming the child for having a normal reaction.
+
+## The big idea
+
+Preschoolers are not mini-adults.
+
+They are not even smaller versions of older children.
+
+They are in a strange and brilliant middle stage.
+
+They can talk, imagine, joke, remember, argue, help, pretend, and love fiercely.
+
+They can also be overwhelmed by socks, bananas, door handles, turn-taking, and the devastating news that bedtime still exists.
+
+The trick is not to lower all expectations.
+
+The trick is to make your expectations more accurate.
+
+A three-year-old can learn boundaries.
+
+A three-year-old can practise waiting.
+
+A three-year-old can begin to talk about feelings.
+
+A three-year-old can repair after hurting someone.
+
+But they will need repetition, help, and a lot of adult calm around the edges.
+
+The sentence I keep coming back to is this:
+
+**Their words are ahead of their regulation.**
+
+Remembering that does not make the hard moments easy.
+
+But it can make them make sense.
+
+And sometimes, as a parent, making sense of the behaviour is the first step towards responding better.
+
+## Sources
+
+- CDC, [Developmental Milestones: 3 Years](https://www.cdc.gov/act-early/milestones/3-years.html)
+- Harvard Center on the Developing Child, [Executive Function & Self-Regulation](https://developingchild.harvard.edu/science/key-concepts/executive-function/)
+- American Academy of Pediatrics, [Temper Tantrums](https://www.healthychildren.org/English/family-life/family-dynamics/communication-discipline/Pages/Temper-Tantrums.aspx)
+- ZERO TO THREE, [Your Calm Is Their Calm: Co-regulation Strategies for Infants and Toddlers](https://www.zerotothree.org/resource/your-calm-is-their-calm-co-regulation-strategies-for-infants-and-toddlers/)
+- NHS, [Help your child learn to talk](https://www.nhs.uk/conditions/baby/babys-development/play-and-learning/help-your-child-learn-to-talk/)


### PR DESCRIPTION
Adds today’s AI-assisted parenting long read as Part 2 of the `Parenting Long Reads` series.

Post added:

- `src/content/blog/why-preschoolers-seem-so-clever-and-so-irrational.md`

Notes:

- uses the new series metadata pattern
- sets `seriesSlug: parenting-long-reads`
- sets `seriesPart: 2`
- keeps the content public-safe by using age/stage wording rather than children’s names or dates of birth
- includes source links in the article body
- leaves publication gated behind this draft PR review